### PR TITLE
Use ThreadMode to replace explicit thread number

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -12,6 +12,7 @@ use super::core;
 use super::encoding;
 use super::memory::Memory;
 use super::result::Result;
+use super::thread_mode::ThreadMode;
 use super::variant::Variant;
 use super::version::Version;
 
@@ -61,12 +62,12 @@ pub fn encoded_len(
 ///
 ///
 /// ```
-/// use argon2::{self, Variant, Version};
+/// use argon2::{self, ThreadMode, Variant, Version};
 ///
 /// let mem_cost = 4096;
 /// let time_cost = 10;
 /// let lanes = 1;
-/// let threads = 1;
+/// let thread_mode = ThreadMode::Sequential;
 /// let pwd = b"password";
 /// let salt = b"somesalt";
 /// let secret = b"secret value";
@@ -77,24 +78,20 @@ pub fn encoded_len(
 ///                                    mem_cost,
 ///                                    time_cost,
 ///                                    lanes,
-///                                    threads,
+///                                    thread_mode,
 ///                                    pwd,
 ///                                    salt,
 ///                                    secret,
 ///                                    ad,
 ///                                    hash_len).unwrap();
 /// ```
-///
-/// # Remarks
-///
-/// The only sensible values for `threads` are `1` and the number of `lanes`.
 pub fn hash_encoded(
     variant: Variant,
     version: Version,
     mem_cost: u32,
     time_cost: u32,
     lanes: u32,
-    threads: u32,
+    thread_mode: ThreadMode,
     pwd: &[u8],
     salt: &[u8],
     secret: &[u8],
@@ -106,7 +103,7 @@ pub fn hash_encoded(
                                     mem_cost,
                                     time_cost,
                                     lanes,
-                                    threads,
+                                    thread_mode,
                                     pwd.to_vec(),
                                     salt.to_vec(),
                                     secret.to_vec(),
@@ -139,7 +136,7 @@ pub fn hash_encoded(
 /// - mem_cost: 4096
 /// - time_cost: 3
 /// - lanes: 1
-/// - threads: 1
+/// - thread_mode: sequential
 /// - secret: empty slice
 /// - ad: empty slice
 /// - hash_len: 32
@@ -149,7 +146,7 @@ pub fn hash_encoded_defaults(pwd: &[u8], salt: &[u8]) -> Result<String> {
                  common::DEF_MEMORY,
                  common::DEF_TIME,
                  common::DEF_LANES,
-                 common::DEF_THREADS,
+                 ThreadMode::default(),
                  pwd,
                  salt,
                  &[],
@@ -186,7 +183,7 @@ pub fn hash_encoded_defaults(pwd: &[u8], salt: &[u8]) -> Result<String> {
 /// The following settings are used:
 ///
 /// - lanes: parallelism
-/// - threads: parallelism
+/// - thread_mode: sequential
 /// - secret: empty slice
 /// - ad: empty slice
 /// ```
@@ -205,7 +202,7 @@ pub fn hash_encoded_std(
                  mem_cost,
                  time_cost,
                  parallelism,
-                 parallelism,
+                 ThreadMode::Sequential,
                  pwd,
                  salt,
                  &[],
@@ -220,12 +217,12 @@ pub fn hash_encoded_std(
 ///
 ///
 /// ```
-/// use argon2::{self, Variant, Version};
+/// use argon2::{self, ThreadMode, Variant, Version};
 ///
 /// let mem_cost = 4096;
 /// let time_cost = 10;
 /// let lanes = 1;
-/// let threads = 1;
+/// let thread_mode = ThreadMode::Sequential;
 /// let pwd = b"password";
 /// let salt = b"somesalt";
 /// let secret = b"secret value";
@@ -236,24 +233,20 @@ pub fn hash_encoded_std(
 ///                            mem_cost,
 ///                            time_cost,
 ///                            lanes,
-///                            threads,
+///                            thread_mode,
 ///                            pwd,
 ///                            salt,
 ///                            secret,
 ///                            ad,
 ///                            hash_len).unwrap();
 /// ```
-///
-/// # Remarks
-///
-/// The only sensible values for `threads` are `1` and the number of `lanes`.
 pub fn hash_raw(
     variant: Variant,
     version: Version,
     mem_cost: u32,
     time_cost: u32,
     lanes: u32,
-    threads: u32,
+    thread_mode: ThreadMode,
     pwd: &[u8],
     salt: &[u8],
     secret: &[u8],
@@ -265,7 +258,7 @@ pub fn hash_raw(
                                     mem_cost,
                                     time_cost,
                                     lanes,
-                                    threads,
+                                    thread_mode,
                                     pwd.to_vec(),
                                     salt.to_vec(),
                                     secret.to_vec(),
@@ -298,7 +291,7 @@ pub fn hash_raw(
 /// - mem_cost: 4096
 /// - time_cost: 3
 /// - lanes: 1
-/// - threads: 1
+/// - thread_mode: sequential
 /// - secret: empty slice
 /// - ad: empty slice
 /// - hash_len: 32
@@ -308,7 +301,7 @@ pub fn hash_raw_defaults(pwd: &[u8], salt: &[u8]) -> Result<Vec<u8>> {
              common::DEF_MEMORY,
              common::DEF_TIME,
              common::DEF_LANES,
-             common::DEF_THREADS,
+             ThreadMode::default(),
              pwd,
              salt,
              &[],
@@ -346,7 +339,7 @@ pub fn hash_raw_defaults(pwd: &[u8], salt: &[u8]) -> Result<Vec<u8>> {
 /// The following settings are used:
 ///
 /// - lanes: parallelism
-/// - threads: parallelism
+/// - thread_mode: sequential
 /// - secret: empty slice
 /// - ad: empty slice
 /// ```
@@ -365,7 +358,7 @@ pub fn hash_raw_std(
              mem_cost,
              time_cost,
              parallelism,
-             parallelism,
+             ThreadMode::Sequential,
              pwd,
              salt,
              &[],
@@ -393,7 +386,7 @@ pub fn verify_encoded(encoded: &str, pwd: &[u8]) -> Result<bool> {
                decoded.mem_cost,
                decoded.time_cost,
                decoded.parallelism,
-               decoded.parallelism,
+               ThreadMode::Parallel,
                pwd,
                &decoded.salt,
                &[],
@@ -407,12 +400,12 @@ pub fn verify_encoded(encoded: &str, pwd: &[u8]) -> Result<bool> {
 ///
 ///
 /// ```
-/// use argon2::{self, Variant, Version};
+/// use argon2::{self, ThreadMode, Variant, Version};
 ///
 /// let mem_cost = 4096;
 /// let time_cost = 3;
 /// let lanes = 1;
-/// let threads = 1;
+/// let thread_mode = ThreadMode::Sequential;
 /// let pwd = b"password";
 /// let salt = b"somesalt";
 /// let secret = &[];
@@ -425,7 +418,7 @@ pub fn verify_encoded(encoded: &str, pwd: &[u8]) -> Result<bool> {
 ///                              mem_cost,
 ///                              time_cost,
 ///                              lanes,
-///                              threads,
+///                              thread_mode,
 ///                              pwd,
 ///                              salt,
 ///                              secret,
@@ -439,7 +432,7 @@ pub fn verify_raw(
     mem_cost: u32,
     time_cost: u32,
     lanes: u32,
-    threads: u32,
+    thread_mode: ThreadMode,
     pwd: &[u8],
     salt: &[u8],
     secret: &[u8],
@@ -451,7 +444,7 @@ pub fn verify_raw(
                                     mem_cost,
                                     time_cost,
                                     lanes,
-                                    threads,
+                                    thread_mode,
                                     pwd.to_vec(),
                                     salt.to_vec(),
                                     secret.to_vec(),
@@ -502,7 +495,7 @@ pub fn verify_raw_std(
                mem_cost,
                time_cost,
                parallelism,
-               parallelism,
+               ThreadMode::Parallel,
                pwd,
                salt,
                &[],

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,15 +15,6 @@ pub const MIN_LANES: u32 = 1;
 /// Maximum number of lanes (degree of parallelism).
 pub const MAX_LANES: u32 = 0x00FFFFFF;
 
-/// Default number of threads.
-pub const DEF_THREADS: u32 = 1;
-
-/// Minimum number of threads.
-pub const MIN_THREADS: u32 = 1;
-
-/// Maximum number of threads.
-pub const MAX_THREADS: u32 = 0x00FFFFFF;
-
 /// Number of synchronization points between lanes per pass.
 pub const SYNC_POINTS: u32 = 4;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,6 +13,7 @@ use super::block::Block;
 use super::common;
 use super::context::Context;
 use super::memory::Memory;
+use super::thread_mode::ThreadMode;
 use super::variant::Variant;
 use super::version::Version;
 
@@ -32,7 +33,7 @@ pub fn initialize(context: &Context, memory: &mut Memory) {
 
 /// Fills all the memory blocks.
 pub fn fill_memory_blocks(context: &Context, memory: &mut Memory) {
-    if context.threads == 1 {
+    if context.thread_mode == ThreadMode::Sequential || context.lanes == 1 {
         fill_memory_blocks_st(context, memory);
     } else {
         fill_memory_blocks_mt(context, memory);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -177,6 +177,7 @@ mod tests {
     use context::Context;
     use decoded::Decoded;
     use error::Error;
+    use thread_mode::ThreadMode;
     use variant::Variant;
     use version::Version;
     use super::*;
@@ -380,7 +381,7 @@ mod tests {
                                    mem_cost,
                                    time_cost,
                                    parallelism,
-                                   parallelism,
+                                   ThreadMode::Parallel,
                                    pwd,
                                    salt,
                                    secret,

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,12 +62,6 @@ pub enum Error {
     /// Incorrect Argon2 variant.
     IncorrectType,
 
-    /// The number of threads is too small (minimum is 1).
-    ThreadsTooFew,
-
-    /// The number of threads is too large (maximum is 2^24 - 1).
-    ThreadsTooMany,
-
     /// The decoding of the encoded data has failed.
     DecodingFail,
 }
@@ -92,8 +86,6 @@ impl Error {
             Error::LanesTooFew => "Too few lanes",
             Error::LanesTooMany => "Too many lanes",
             Error::IncorrectType => "There is no such version of Argon2",
-            Error::ThreadsTooFew => "Not enough threads",
-            Error::ThreadsTooMany => "Too many threads",
             Error::DecodingFail => "Decoding failed",
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,11 +91,13 @@ mod encoding;
 mod error;
 mod memory;
 mod result;
+mod thread_mode;
 mod variant;
 mod version;
 
 pub use argon2::*;
 pub use error::Error;
 pub use result::Result;
+pub use thread_mode::ThreadMode;
 pub use variant::Variant;
 pub use version::Version;

--- a/src/thread_mode.rs
+++ b/src/thread_mode.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Xidorn Quan <me@upsuper.org>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// The thread mode used to perform the hashing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThreadMode {
+    /// Run in one thread.
+    Sequential,
+
+    /// Run in the same number of threads as the number of lanes.
+    Parallel,
+}
+
+impl Default for ThreadMode {
+    fn default() -> ThreadMode {
+        ThreadMode::Sequential
+    }
+}


### PR DESCRIPTION
There are several advantages to use a thread mode instead of explicit thread number:
1. all values of thread mode are sensible, while only restricted values of thread number makes sense
2. errors for thread number are no longer necessary