### PR TITLE
Use reference to bytes data

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -104,10 +104,10 @@ pub fn hash_encoded(
                                     time_cost,
                                     lanes,
                                     thread_mode,
-                                    pwd.to_vec(),
-                                    salt.to_vec(),
-                                    secret.to_vec(),
-                                    ad.to_vec(),
+                                    pwd,
+                                    salt,
+                                    secret,
+                                    ad,
                                     hash_len));
     let hash = run(&context);
     let encoded = encoding::encode_string(&context, &hash);
@@ -259,10 +259,10 @@ pub fn hash_raw(
                                     time_cost,
                                     lanes,
                                     thread_mode,
-                                    pwd.to_vec(),
-                                    salt.to_vec(),
-                                    secret.to_vec(),
-                                    ad.to_vec(),
+                                    pwd,
+                                    salt,
+                                    secret,
+                                    ad,
                                     hash_len));
     let hash = run(&context);
     Ok(hash)
@@ -445,10 +445,10 @@ pub fn verify_raw(
                                     time_cost,
                                     lanes,
                                     thread_mode,
-                                    pwd.to_vec(),
-                                    salt.to_vec(),
-                                    secret.to_vec(),
-                                    ad.to_vec(),
+                                    pwd,
+                                    salt,
+                                    secret,
+                                    ad,
                                     hash.len() as u32));
     Ok(run(&context) == hash)
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -353,14 +353,14 @@ fn h0(context: &Context) -> [u8; common::PREHASH_SEED_LENGTH] {
                  &u32_as_32le(context.time_cost),
                  &u32_as_32le(context.version.as_u32()),
                  &u32_as_32le(context.variant.as_u32()),
-                 &len_as_32le(&context.pwd),
-                 context.pwd.as_slice(),
-                 &len_as_32le(&context.salt),
-                 context.salt.as_slice(),
-                 &len_as_32le(&context.secret),
-                 context.secret.as_slice(),
-                 &len_as_32le(&context.ad),
-                 context.ad.as_slice()];
+                 &len_as_32le(context.pwd),
+                 context.pwd.as_ref(),
+                 &len_as_32le(context.salt),
+                 context.salt.as_ref(),
+                 &len_as_32le(context.secret),
+                 context.secret.as_ref(),
+                 &len_as_32le(context.ad),
+                 context.ad.as_ref()];
     let mut out = [0u8; common::PREHASH_SEED_LENGTH];
     blake2b(&mut out[0..common::PREHASH_DIGEST_LENGTH], &input);
     out

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -382,10 +382,10 @@ mod tests {
                                    time_cost,
                                    parallelism,
                                    ThreadMode::Parallel,
-                                   pwd,
-                                   salt,
-                                   secret,
-                                   ad,
+                                   &pwd,
+                                   &salt,
+                                   &secret,
+                                   &ad,
                                    hash_length)
             .unwrap();
         let expected = "$argon2i$v=19$m=4096,t=3,p=1\


### PR DESCRIPTION
To avoid the unnecessary copy.