### PR TITLE
Run only integration-tests on release test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --release --verbose
-  - cargo test --release --verbose -- --test-threads=1
+  - cargo test --release --test integration_test --verbose -- --test-threads=2


### PR DESCRIPTION
And try to run with two threads.

This should be much faster than the current setting.