### PR TITLE
Replace rustc-serialize crate with base64 and hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["argon2", "argon2d", "argon2i", "hash", "password"]
 name = "argon2"
 
 [dependencies]
+base64 = "0.5.2"
 blake2-rfc = "0.2.17"
 crossbeam = "0.2.10"
-rustc-serialize = "0.3.22"
+
+[dev-dependencies]
+hex = "0.2.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use base64;
 use std::{error, fmt};
 
 /// Error type for Argon2 errors.
@@ -108,5 +109,11 @@ impl error::Error for Error {
 
     fn cause(&self) -> Option<&error::Error> {
         None
+    }
+}
+
+impl From<base64::DecodeError> for Error {
+    fn from(_: base64::DecodeError) -> Self {
+        Error::DecodingFail
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,9 @@
 //! - `verify_raw_std`
 
 
+extern crate base64;
 extern crate blake2_rfc;
 extern crate crossbeam;
-extern crate rustc_serialize;
 
 mod argon2;
 mod block;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,10 +9,10 @@
 // These tests are based on Argon's test.c test suite.
 
 extern crate argon2;
-extern crate rustc_serialize;
+extern crate hex;
 
 use argon2::{Error, Config, ThreadMode, Variant, Version};
-use rustc_serialize::hex::ToHex;
+use hex::ToHex;
 
 #[cfg(not(debug_assertions))]
 #[test]


### PR DESCRIPTION
This also changes the expected result of test encode_string_returns_correct_string. It is not clear to me why the old code encodes base64 without padding, while decoding tests include padding. It doesn't make much sense to have such inconsistency, so I think this change should be fine.

This fixes #9.