### PR TITLE
Convert Config to an owned object

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -163,8 +163,8 @@ pub fn hash_encoded_defaults(pwd: &[u8], salt: &[u8]) -> Result<String> {
 ///     time_cost: 10,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: b"secret value",
-///     ad: b"associated data",
+///     secret: b"secret value".to_vec(),
+///     ad: b"associated data".to_vec(),
 ///     hash_length: 32,
 /// };
 /// let encoded = argon2::hash_encoded(pwd, salt, &config).unwrap();
@@ -190,8 +190,8 @@ pub fn hash_encoded_old(
         time_cost: time_cost,
         lanes: lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret: secret.to_vec(),
+        ad: ad.to_vec(),
         hash_length: hash_len,
     };
     hash_encoded(pwd, salt, &config)
@@ -235,8 +235,8 @@ pub fn hash_encoded_old(
 ///     time_cost: 10,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: &[],
-///     ad: &[],
+///     secret: vec![],
+///     ad: vec![],
 ///     hash_length: 32,
 /// };
 /// let encoded = argon2::hash_encoded(pwd, salt, &config).unwrap();
@@ -259,8 +259,8 @@ pub fn hash_encoded_std(
         time_cost: time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: hash_len,
     };
     hash_encoded(pwd, salt, &config)
@@ -372,8 +372,8 @@ pub fn hash_raw_defaults(pwd: &[u8], salt: &[u8]) -> Result<Vec<u8>> {
 ///     time_cost: 10,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: b"secret value",
-///     ad: b"associated data",
+///     secret: b"secret value".to_vec(),
+///     ad: b"associated data".to_vec(),
 ///     hash_length: 32,
 /// };
 /// let vec = argon2::hash_raw(pwd, salt, &config);
@@ -399,8 +399,8 @@ pub fn hash_raw_old(
         time_cost: time_cost,
         lanes: lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret: secret.to_vec(),
+        ad: ad.to_vec(),
         hash_length: hash_len,
     };
     hash_raw(pwd, salt, &config)
@@ -444,8 +444,8 @@ pub fn hash_raw_old(
 ///     time_cost: 10,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: &[],
-///     ad: &[],
+///     secret: vec![],
+///     ad: vec![],
 ///     hash_length: 32,
 /// };
 /// let vec = argon2::hash_raw(pwd, salt, &config);
@@ -468,8 +468,8 @@ pub fn hash_raw_std(
         time_cost: time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: hash_len,
     };
     hash_raw(pwd, salt, &config)
@@ -497,8 +497,8 @@ pub fn verify_encoded(encoded: &str, pwd: &[u8]) -> Result<bool> {
         time_cost: decoded.time_cost,
         lanes: decoded.parallelism,
         thread_mode: ThreadMode::from_threads(decoded.parallelism),
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: decoded.hash.len() as u32,
     };
     verify_raw(pwd, &decoded.salt, &decoded.hash, &config)
@@ -579,8 +579,8 @@ pub fn verify_raw(pwd: &[u8], salt: &[u8], hash: &[u8], config: &Config) -> Resu
 ///     time_cost: 3,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: &[],
-///     ad: &[],
+///     secret: vec![],
+///     ad: vec![],
 ///     hash_length: hash.len() as u32,
 /// };
 /// let res = argon2::verify_raw(pwd, salt, hash, &config).unwrap();
@@ -607,8 +607,8 @@ pub fn verify_raw_old(
         time_cost: time_cost,
         lanes: lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret: secret.to_vec(),
+        ad: ad.to_vec(),
         hash_length: hash.len() as u32,
     };
     verify_raw(pwd, salt, hash, &config)
@@ -658,8 +658,8 @@ pub fn verify_raw_old(
 ///     time_cost: 3,
 ///     lanes: 1,
 ///     thread_mode: ThreadMode::Sequential,
-///     secret: &[],
-///     ad: &[],
+///     secret: vec![],
+///     ad: vec![],
 ///     hash_length: hash.len() as u32,
 /// };
 /// let res = argon2::verify_raw(pwd, salt, hash, &config).unwrap();
@@ -683,8 +683,8 @@ pub fn verify_raw_std(
         time_cost: time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: hash.len() as u32,
     };
     verify_raw(pwd, salt, hash, &config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,9 +30,9 @@ use super::version::Version;
 /// assert_eq!(config.version, Version::Version13);
 /// ```
 #[derive(Clone, Debug, PartialEq)]
-pub struct Config<'a> {
+pub struct Config {
     /// The associated data.
-    pub ad: &'a [u8],
+    pub ad: Vec<u8>,
 
     /// The length of the resulting hash.
     pub hash_length: u32,
@@ -44,7 +44,7 @@ pub struct Config<'a> {
     pub mem_cost: u32,
 
     /// The key.
-    pub secret: &'a [u8],
+    pub secret: Vec<u8>,
 
     /// The thread mode.
     pub thread_mode: ThreadMode,
@@ -59,20 +59,20 @@ pub struct Config<'a> {
     pub version: Version,
 }
 
-impl<'a> Config<'a> {
+impl Config {
     pub fn uses_sequential(&self) -> bool {
         self.thread_mode == ThreadMode::Sequential || self.lanes == 1
     }
 }
 
-impl<'a> Default for Config<'a> {
-    fn default() -> Config<'a> {
+impl Default for Config {
+    fn default() -> Config {
         Config {
-            ad: &[],
+            ad: vec![],
             hash_length: common::DEF_HASH_LENGTH,
             lanes: common::DEF_LANES,
             mem_cost: common::DEF_MEMORY,
-            secret: &[],
+            secret: vec![],
             thread_mode: ThreadMode::default(),
             time_cost: common::DEF_TIME,
             variant: Variant::default(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,7 +16,7 @@ use super::result::Result;
 #[derive(Debug, PartialEq)]
 pub struct Context<'a> {
     /// The config for this context.
-    pub config: Config<'a>,
+    pub config: Config,
 
     /// The length of a lane.
     pub lane_length: u32,
@@ -36,7 +36,7 @@ pub struct Context<'a> {
 
 impl<'a> Context<'a> {
     /// Attempts to create a new context.
-    pub fn new(config: Config<'a>, pwd: &'a [u8], salt: &'a [u8]) -> Result<Context<'a>> {
+    pub fn new(config: Config, pwd: &'a [u8], salt: &'a [u8]) -> Result<Context<'a>> {
         if config.lanes < common::MIN_LANES {
             return Err(Error::LanesTooFew);
         } else if config.lanes > common::MAX_LANES {
@@ -125,11 +125,11 @@ mod tests {
     #[test]
     fn new_returns_correct_instance() {
         let config = Config {
-            ad: b"additionaldata",
+            ad: b"additionaldata".to_vec(),
             hash_length: 32,
             lanes: 4,
             mem_cost: 4096,
-            secret: b"secret",
+            secret: b"secret".to_vec(),
             thread_mode: ThreadMode::Sequential,
             time_cost: 3,
             variant: Variant::Argon2i,

--- a/src/core.rs
+++ b/src/core.rs
@@ -359,9 +359,9 @@ fn h0(context: &Context) -> [u8; common::PREHASH_SEED_LENGTH] {
         context.pwd.as_ref(),
         &len_as_32le(context.salt),
         context.salt.as_ref(),
-        &len_as_32le(context.config.secret),
+        &len_as_32le(&context.config.secret),
         context.config.secret.as_ref(),
-        &len_as_32le(context.config.ad),
+        &len_as_32le(&context.config.ad),
         context.config.ad.as_ref(),
     ];
     let mut out = [0u8; common::PREHASH_SEED_LENGTH];

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -367,11 +367,11 @@ mod tests {
     fn encode_string_returns_correct_string() {
         let hash = b"12345678901234567890123456789012".to_vec();
         let config = Config {
-            ad: &[],
+            ad: vec![],
             hash_length: hash.len() as u32,
             lanes: 1,
             mem_cost: 4096,
-            secret: &[],
+            secret: vec![],
             thread_mode: ThreadMode::Parallel,
             time_cost: 3,
             variant: Variant::Argon2i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@
 //!     time_cost: 10,
 //!     lanes: 4,
 //!     thread_mode: ThreadMode::Parallel,
-//!     secret: &[],
-//!     ad: &[],
+//!     secret: vec![],
+//!     ad: vec![],
 //!     hash_length: 32
 //! };
 //! let hash = argon2::hash_encoded(password, salt, &config).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1012,8 +1012,8 @@ fn test_hash_raw_with_not_enough_memory() {
         time_cost: 2,
         lanes: 1,
         thread_mode: ThreadMode::Sequential,
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: 32,
     };
     let res = argon2::hash_raw(pwd, salt, &config);
@@ -1031,8 +1031,8 @@ fn test_hash_raw_with_too_short_salt() {
         time_cost: 2,
         lanes: 1,
         thread_mode: ThreadMode::Sequential,
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: 32,
     };
     let res = argon2::hash_raw(pwd, salt, &config);
@@ -1057,8 +1057,8 @@ fn hash_test(
         time_cost: t,
         lanes: p,
         thread_mode: ThreadMode::from_threads(p),
-        secret: &[],
-        ad: &[],
+        secret: vec![],
+        ad: vec![],
         hash_length: 32,
     };
     let hash = argon2::hash_raw(pwd, salt, &config).unwrap();


### PR DESCRIPTION
This is an ergonomics improvement, as otherwise users of `argon2::Config` need to make the key's and associated data's lifetime part of their own configuration object's lifetime parameter.

See [oxynote!2](https://gitlab.com/mekagoza/oxynote/merge_requests/2) for an example; I was even unable to use `rust-argon2` as-is there, because the `actix` web framework assumes static bounds, for some of its traits, that couldn't be fullfilled simultaneously to the one from `argon2::Config`.