### PR TITLE
Dependencies update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ blake2-rfc = "0.2"
 crossbeam = "0.2.10"
 
 [dev-dependencies]
-hex = "0.2.0"
+hex = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "argon2"
 [dependencies]
 base64 = "0.10"
 blake2-rfc = "0.2"
-crossbeam = "0.2.10"
+crossbeam = "0.5"
 
 [dev-dependencies]
 hex = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["argon2", "argon2d", "argon2i", "hash", "password"]
 name = "argon2"
 
 [dependencies]
-base64 = "0.6.0"
+base64 = "0.10"
 blake2-rfc = "0.2.17"
 crossbeam = "0.2.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "argon2"
 
 [dependencies]
 base64 = "0.10"
-blake2-rfc = "0.2.17"
+blake2-rfc = "0.2"
 crossbeam = "0.2.10"
 
 [dev-dependencies]

--- a/src/core.rs
+++ b/src/core.rs
@@ -214,14 +214,14 @@ fn fill_first_blocks(context: &Context, memory: &mut Memory, h0: &mut [u8]) {
 fn fill_memory_blocks_mt(context: &Context, memory: &mut Memory) {
     for p in 0..context.config.time_cost {
         for s in 0..common::SYNC_POINTS {
-            scope(|scoped| for (l, mem) in (0..context.config.lanes).zip(memory.as_lanes_mut()) {
+            let _ = scope(|scoped| for (l, mem) in (0..context.config.lanes).zip(memory.as_lanes_mut()) {
                 let position = Position {
                     pass: p,
                     lane: l,
                     slice: s,
                     index: 0,
                 };
-                scoped.spawn(move || { fill_segment(context, &position, mem); });
+                scoped.spawn(move |_| { fill_segment(context, &position, mem); });
             });
         }
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use base64;
-use base64::{CharacterSet, Config as Base64Config, LineWrap};
 use super::context::Context;
 use super::decoded::Decoded;
 use super::error::Error;
@@ -134,8 +133,6 @@ fn decode_version(str: &str) -> Result<Version> {
 
 /// Encodes the hash and context.
 pub fn encode_string(context: &Context, hash: &Vec<u8>) -> String {
-    // Temporary: https://github.com/alicemaz/rust-base64/pull/38
-    let base64_config = Base64Config::new(CharacterSet::Standard, false, false, LineWrap::NoWrap);
     format!(
         "${}$v={}$m={},t={},p={}${}${}",
         context.config.variant,
@@ -143,8 +140,8 @@ pub fn encode_string(context: &Context, hash: &Vec<u8>) -> String {
         context.config.mem_cost,
         context.config.time_cost,
         context.config.lanes,
-        base64::encode_config(context.salt, base64_config),
-        base64::encode_config(hash, base64_config),
+        base64::encode_config(context.salt, base64::STANDARD_NO_PAD),
+        base64::encode_config(hash, base64::STANDARD_NO_PAD),
     )
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1062,7 +1062,10 @@ fn hash_test(
         hash_length: 32,
     };
     let hash = argon2::hash_raw(pwd, salt, &config).unwrap();
-    assert_eq!(hash.to_hex(), hex);
+    let mut hex_str = String::new();
+    let res = hash.write_hex(&mut hex_str);
+    assert_eq!(res, Ok(()));
+    assert_eq!(hex_str.as_str(), hex);
 
     let encoded = argon2::hash_encoded(pwd, salt, &config).unwrap();
     let result = argon2::verify_encoded(encoded.as_str(), pwd).unwrap();


### PR DESCRIPTION
Hello,

This pull request updates the now outdated dependencies. This is motivated mostly by a vulnerability in crossbeam ([RUSTSEC-2018-0009](https://github.com/RustSec/advisory-db/blob/master/crates/crossbeam/RUSTSEC-2018-0009.toml)). Even if only crossbeam 4.0.0 is affected, the [cargo-audit](https://github.com/RustSec/cargo-audit) does prompt an error for every project having crossbeam < 0.4.1 in its dependencies (or dependencies of dependencies, hence in every project using rust-argon2).
Also, I labeled the dependencies without the patch version in order to allow automatic updates for new patch releases with `cargo update`.