### PR TITLE
SIMD blake hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "argon2"
 
 [dependencies]
 base64 = "0.10"
-blake2-rfc = "0.2"
+blake2b_simd = "0.5"
 crossbeam = "0.5"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,8 @@
 //! This version uses the standard implementation and does not yet implement
 //! optimizations. Therefore, it is not the fastest implementation available.
 
-
 extern crate base64;
-extern crate blake2_rfc;
+extern crate blake2b_simd;
 extern crate crossbeam;
 
 mod argon2;


### PR DESCRIPTION
This PR migrates to the [blake2b_simd crate](https://crates.io/crates/blake2b_simd) which should offer some speedup over the current crate.

I also changed the `clone_from_slice` function to `copy_from_slice` cutting down on the unneeded calls to clone since `u8` implements `Copy`.

There are some mixed in `rustfmt` changes which I can remove if wanted as well.