### PR TITLE
Update crossbeam dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "argon2"
 [dependencies]
 base64 = "0.10"
 blake2b_simd = "0.5"
-crossbeam = "0.5"
+crossbeam = "0.7"
 
 [dev-dependencies]
 hex = "0.3"


### PR DESCRIPTION
rust-argon2 is currently pulling in a few old crates by depending on an old crossbeam release.

This update also resolves #16.

Please release a new version after merging this patch.