### PR TITLE
Use crossbeam utils instead of crossbeam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ ChangeLog for rust-argon2
 This documents all notable changes to
 [rust-argon2](https://github.com/sru-systems/rust-argon2).
 
+## 0.5.1
+
+- Use crossbeam utils 0.6 instead of crossbeam 0.5
+
 
 ## 0.5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "argon2"
 [dependencies]
 base64 = "0.10"
 blake2b_simd = "0.5"
-crossbeam = "0.7"
+crossbeam-utils = "0.6"
 
 [dev-dependencies]
 hex = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-argon2"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Martijn Rijkeboer <mrr@sru-systems.com>"]
 license = "MIT/Apache-2.0"
 description = "Rust implementation of the Argon2 password hashing function."
@@ -16,7 +16,7 @@ name = "argon2"
 [dependencies]
 base64 = "0.10"
 blake2b_simd = "0.5"
-crossbeam = "0.5"
+crossbeam = "0.7"
 
 [dev-dependencies]
 hex = "0.3"

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,7 +13,7 @@ use super::memory::Memory;
 use super::variant::Variant;
 use super::version::Version;
 use blake2b_simd::Params;
-use crossbeam::scope;
+use crossbeam_utils::thread::scope;
 use std::mem;
 
 /// Position of the block currently being operated on.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 
 extern crate base64;
 extern crate blake2b_simd;
-extern crate crossbeam;
+extern crate crossbeam_utils;
 
 mod argon2;
 mod block;


### PR DESCRIPTION
Currently, rust-argon2 requires memoffset 0.2.1 to be used in the following chain:

```
memoffset v0.2.1
└── crossbeam-epoch v0.6.1
    └── crossbeam v0.5.0
        └── rust-argon2 v0.5.0
```

which is vulnerable to RUSTSEC-2019-0011:

```
ID:      RUSTSEC-2019-0011
Crate:   memoffset
Version: 0.2.1
Date:    2019-07-16
URL:     https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490
Title:   Flaw in offset_of and span_of causes SIGILL, potential memory unsafety
Solution: upgrade to: >= 0.5.0
```

It looks like rust-argon2 should be able to use crossbeam 0.7 easily, and with no change to the public API.

Is it possible to merge this, and push a 0.5.1 release?