### PR TITLE
Fix bare_trait_objects warning

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -107,7 +107,7 @@ impl error::Error for Error {
         self.msg()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }


### PR DESCRIPTION
This fixes the bare_trait_objects warning by using &dyn error::Error instead of just &error::Error