### PR TITLE
2018 edition and fixed most clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-argon2"
 version = "0.5.1"
 authors = ["Martijn Rijkeboer <mrr@sru-systems.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "Rust implementation of the Argon2 password hashing function."
 documentation = "https://docs.sru-systems.com/rust-argon2/0.5.0/argon2/"

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -184,14 +184,14 @@ pub fn hash_encoded_old(
     hash_len: u32,
 ) -> Result<String> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
-        lanes: lanes,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
+        lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret,
+        ad,
         hash_length: hash_len,
     };
     hash_encoded(pwd, salt, &config)
@@ -253,10 +253,10 @@ pub fn hash_encoded_std(
     hash_len: u32,
 ) -> Result<String> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
         secret: &[],
@@ -393,14 +393,14 @@ pub fn hash_raw_old(
     hash_len: u32,
 ) -> Result<Vec<u8>> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
-        lanes: lanes,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
+        lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret,
+        ad,
         hash_length: hash_len,
     };
     hash_raw(pwd, salt, &config)
@@ -462,10 +462,10 @@ pub fn hash_raw_std(
     hash_len: u32,
 ) -> Result<Vec<u8>> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
         secret: &[],
@@ -516,8 +516,8 @@ pub fn verify_encoded_ext(encoded: &str, pwd: &[u8], secret: &[u8], ad: &[u8]) -
         time_cost: decoded.time_cost,
         lanes: decoded.parallelism,
         thread_mode: ThreadMode::from_threads(decoded.parallelism),
-        secret: secret,
-        ad: ad,
+        secret,
+        ad,
         hash_length: decoded.hash.len() as u32,
     };
     verify_raw(pwd, &decoded.salt, &decoded.hash, &config)
@@ -620,14 +620,14 @@ pub fn verify_raw_old(
     hash: &[u8],
 ) -> Result<bool> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
-        lanes: lanes,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
+        lanes,
         thread_mode: ThreadMode::from_threads(threads),
-        secret: secret,
-        ad: ad,
+        secret,
+        ad,
         hash_length: hash.len() as u32,
     };
     verify_raw(pwd, salt, hash, &config)
@@ -696,10 +696,10 @@ pub fn verify_raw_std(
     hash: &[u8],
 ) -> Result<bool> {
     let config = Config {
-        variant: variant,
-        version: version,
-        mem_cost: mem_cost,
-        time_cost: time_cost,
+        variant,
+        version,
+        mem_cost,
+        time_cost,
         lanes: parallelism,
         thread_mode: ThreadMode::from_threads(parallelism),
         secret: &[],

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -37,7 +37,7 @@ use crate::version::Version;
 /// let enc_len = argon2::encoded_len(variant, mem, time, parallelism, salt_len, hash_len);
 /// assert_eq!(enc_len, 86);
 /// ```
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 pub fn encoded_len(
     variant: Variant,
     mem_cost: u32,

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -6,15 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::context::Context;
-use super::config::Config;
-use super::core;
-use super::encoding;
-use super::memory::Memory;
-use super::result::Result;
-use super::thread_mode::ThreadMode;
-use super::variant::Variant;
-use super::version::Version;
+use crate::context::Context;
+use crate::config::Config;
+use crate::core;
+use crate::encoding;
+use crate::memory::Memory;
+use crate::result::Result;
+use crate::thread_mode::ThreadMode;
+use crate::variant::Variant;
+use crate::version::Version;
 
 /// Returns the length of the encoded string.
 ///

--- a/src/block.rs
+++ b/src/block.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{fmt, mem};
+use std::fmt;
 use std::fmt::Debug;
 use std::ops::{BitXorAssign, Index, IndexMut};
 use crate::common;
@@ -17,13 +17,13 @@ pub struct Block([u64; common::QWORDS_IN_BLOCK]);
 impl Block {
     /// Gets the byte slice representation of the block.
     pub fn as_u8(&self) -> &[u8] {
-        let bytes: &[u8; common::BLOCK_SIZE] = unsafe { mem::transmute(&self.0) };
+        let bytes: &[u8; common::BLOCK_SIZE] = unsafe { &*(&self.0 as *const [u64; 128] as *const [u8; 1024]) };
         bytes
     }
 
     /// Gets the mutable byte slice representation of the block.
     pub fn as_u8_mut(&mut self) -> &mut [u8] {
-        let bytes: &mut [u8; common::BLOCK_SIZE] = unsafe { mem::transmute(&mut self.0) };
+        let bytes: &mut [u8; common::BLOCK_SIZE] = unsafe { &mut *(&mut self.0 as *mut [u64; 128] as *mut [u8; 1024]) };
         bytes
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -17,13 +17,13 @@ pub struct Block([u64; common::QWORDS_IN_BLOCK]);
 impl Block {
     /// Gets the byte slice representation of the block.
     pub fn as_u8(&self) -> &[u8] {
-        let bytes: &[u8; common::BLOCK_SIZE] = unsafe { &*(&self.0 as *const [u64; 128] as *const [u8; 1024]) };
+        let bytes: &[u8; common::BLOCK_SIZE] = unsafe { &*(&self.0 as *const [u64; common::QWORDS_IN_BLOCK] as *const [u8; common::BLOCK_SIZE]) };
         bytes
     }
 
     /// Gets the mutable byte slice representation of the block.
     pub fn as_u8_mut(&mut self) -> &mut [u8] {
-        let bytes: &mut [u8; common::BLOCK_SIZE] = unsafe { &mut *(&mut self.0 as *mut [u64; 128] as *mut [u8; 1024]) };
+        let bytes: &mut [u8; common::BLOCK_SIZE] = unsafe { &mut *(&mut self.0 as *mut [u64; common::QWORDS_IN_BLOCK] as *mut [u8; common::BLOCK_SIZE]) };
         bytes
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -9,7 +9,7 @@
 use std::{fmt, mem};
 use std::fmt::Debug;
 use std::ops::{BitXorAssign, Index, IndexMut};
-use super::common;
+use crate::common;
 
 /// Structure for the (1KB) memory block implemented as 128 64-bit words.
 pub struct Block([u64; common::QWORDS_IN_BLOCK]);
@@ -91,8 +91,8 @@ impl PartialEq for Block {
 #[cfg(test)]
 mod tests {
 
-    use common;
-    use super::*;
+    use crate::block::Block;
+    use crate::common;
 
     #[test]
     fn as_u8_returns_correct_slice() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,7 +13,7 @@ pub const DEF_LANES: u32 = 1;
 pub const MIN_LANES: u32 = 1;
 
 /// Maximum number of lanes (degree of parallelism).
-pub const MAX_LANES: u32 = 0x00FFFFFF;
+pub const MAX_LANES: u32 = 0x00FF_FFFF;
 
 /// Number of synchronization points between lanes per pass.
 pub const SYNC_POINTS: u32 = 4;
@@ -25,7 +25,7 @@ pub const DEF_HASH_LENGTH: u32 = 32;
 pub const MIN_HASH_LENGTH: u32 = 4;
 
 /// Maximum digest size in bytes.
-pub const MAX_HASH_LENGTH: u32 = 0xFFFFFFFF;
+pub const MAX_HASH_LENGTH: u32 = 0xFFFF_FFFF;
 
 /// Default number of memory blocks (2^12).
 pub const DEF_MEMORY: u32 = 4096;
@@ -37,7 +37,7 @@ pub const MIN_MEMORY: u32 = 2 * SYNC_POINTS;
 #[cfg(target_pointer_width = "32")]
 pub const MAX_MEMORY: u32 = 0x200000;
 #[cfg(target_pointer_width = "64")]
-pub const MAX_MEMORY: u32 = 0xFFFFFFFF;
+pub const MAX_MEMORY: u32 = 0xFFFF_FFFF;
 
 /// Default number of passes.
 pub const DEF_TIME: u32 = 3;
@@ -46,31 +46,31 @@ pub const DEF_TIME: u32 = 3;
 pub const MIN_TIME: u32 = 1;
 
 /// Maximum number of passes.
-pub const MAX_TIME: u32 = 0xFFFFFFFF;
+pub const MAX_TIME: u32 = 0xFFFF_FFFF;
 
 /// Minimum password length in bytes.
 pub const MIN_PWD_LENGTH: u32 = 0;
 
 /// Maximum password length in bytes.
-pub const MAX_PWD_LENGTH: u32 = 0xFFFFFFFF;
+pub const MAX_PWD_LENGTH: u32 = 0xFFFF_FFFF;
 
 /// Minimum associated data length in bytes.
 pub const MIN_AD_LENGTH: u32 = 0;
 
 /// Maximum associated data length in bytes.
-pub const MAX_AD_LENGTH: u32 = 0xFFFFFFFF;
+pub const MAX_AD_LENGTH: u32 = 0xFFFF_FFFF;
 
 /// Minimum salt length in bytes.
 pub const MIN_SALT_LENGTH: u32 = 8;
 
 /// Maximum salt length in bytes.
-pub const MAX_SALT_LENGTH: u32 = 0xFFFFFFFF;
+pub const MAX_SALT_LENGTH: u32 = 0xFFFF_FFFF;
 
 /// Minimum key length in bytes.
 pub const MIN_SECRET_LENGTH: u32 = 0;
 
 /// Maximum key length in bytes.
-pub const MAX_SECRET_LENGTH: u32 = 0xFFFFFFFF;
+pub const MAX_SECRET_LENGTH: u32 = 0xFFFF_FFFF;
 
 /// Memory block size in bytes.
 pub const BLOCK_SIZE: usize = 1024;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::common;
-use super::thread_mode::ThreadMode;
-use super::variant::Variant;
-use super::version::Version;
+use crate::common;
+use crate::thread_mode::ThreadMode;
+use crate::variant::Variant;
+use crate::version::Version;
 
 /// Structure containing configuration settings.
 ///
@@ -85,9 +85,10 @@ impl<'a> Default for Config<'a> {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
-    use variant::Variant;
-    use version::Version;
+    use crate::config::Config;
+    use crate::thread_mode::ThreadMode;
+    use crate::variant::Variant;
+    use crate::version::Version;
 
     #[test]
     fn default_returns_correct_instance() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -102,12 +102,12 @@ impl<'a> Context<'a> {
         let lane_length = segment_length * common::SYNC_POINTS;
 
         Ok(Context {
-            config: config,
-            lane_length: lane_length,
-            memory_blocks: memory_blocks,
-            pwd: pwd,
-            salt: salt,
-            segment_length: segment_length,
+            config,
+            lane_length,
+            memory_blocks,
+            pwd,
+            salt,
+            segment_length,
         })
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::common;
-use super::config::Config;
-use super::error::Error;
-use super::result::Result;
+use crate::common;
+use crate::config::Config;
+use crate::error::Error;
+use crate::result::Result;
 
 /// Structure containing settings for the Argon2 algorithm. A combination of
 /// the original argon2_context and argon2_instance_t.
@@ -116,11 +116,12 @@ impl<'a> Context<'a> {
 #[cfg(test)]
 mod tests {
 
-    use error::Error;
-    use super::*;
-    use thread_mode::ThreadMode;
-    use variant::Variant;
-    use version::Version;
+    use crate::config::Config;
+    use crate::context::Context;
+    use crate::error::Error;
+    use crate::thread_mode::ThreadMode;
+    use crate::variant::Variant;
+    use crate::version::Version;
 
     #[test]
     fn new_returns_correct_instance() {

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,12 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::block::Block;
-use super::common;
-use super::context::Context;
-use super::memory::Memory;
-use super::variant::Variant;
-use super::version::Version;
+use crate::block::Block;
+use crate::common;
+use crate::context::Context;
+use crate::memory::Memory;
+use crate::variant::Variant;
+use crate::version::Version;
 use blake2b_simd::Params;
 use crossbeam_utils::thread::scope;
 use std::mem;

--- a/src/core.rs
+++ b/src/core.rs
@@ -61,7 +61,7 @@ fn blake2b(out: &mut [u8], input: &[&[u8]]) {
 }
 
 fn f_bla_mka(x: u64, y: u64) -> u64 {
-    let m = 0xFFFFFFFFu64;
+    let m = 0xFFFF_FFFFu64;
     let xy = (x & m) * (y & m);
     x.wrapping_add(y.wrapping_add(xy.wrapping_add(xy)))
 }
@@ -278,15 +278,12 @@ fn fill_segment(context: &Context, position: &Position, memory: &mut Memory) {
         }
 
         // 1.2.2 Computing the lane of the reference block
-        let mut ref_lane = (pseudo_rand >> 32) % context.config.lanes as u64;
-        if (position.pass == 0) && (position.slice == 0) {
-            // Can not reference other lanes yet
-            ref_lane = position.lane as u64;
-        }
+        // If (position.pass == 0) && (position.slice == 0): can not reference other lanes yet
+        let ref_lane = if (position.pass == 0) && (position.slice == 0) { position.lane as u64 } else { (pseudo_rand >> 32) % context.config.lanes as u64 };
 
         // 1.2.3 Computing the number of possible reference block within the lane.
         position.index = i;
-        let pseudo_rand_u32 = (pseudo_rand & 0xFFFFFFFF) as u32;
+        let pseudo_rand_u32 = (pseudo_rand & 0xFFFF_FFFF) as u32;
         let same_lane = ref_lane == (position.lane as u64);
         let ref_index = index_alpha(context, &position, pseudo_rand_u32, same_lane);
 
@@ -294,16 +291,12 @@ fn fill_segment(context: &Context, position: &Position, memory: &mut Memory) {
         let index = context.lane_length as u64 * ref_lane + ref_index as u64;
         let mut curr_block = memory[curr_offset].clone();
         {
-            let ref prev_block = memory[prev_offset];
-            let ref ref_block = memory[index];
-            if context.config.version == Version::Version10 {
+            let prev_block = &memory[prev_offset];
+            let ref_block = &memory[index];
+            if context.config.version == Version::Version10 || position.pass == 0 {
                 fill_block(prev_block, ref_block, &mut curr_block, false);
             } else {
-                if position.pass == 0 {
-                    fill_block(prev_block, ref_block, &mut curr_block, false);
-                } else {
-                    fill_block(prev_block, ref_block, &mut curr_block, true);
-                }
+                fill_block(prev_block, ref_block, &mut curr_block, true);
             }
         }
 
@@ -333,13 +326,13 @@ fn h0(context: &Context) -> [u8; common::PREHASH_SEED_LENGTH] {
         &u32_as_32le(context.config.version.as_u32()),
         &u32_as_32le(context.config.variant.as_u32()),
         &len_as_32le(context.pwd),
-        context.pwd.as_ref(),
+        context.pwd,
         &len_as_32le(context.salt),
-        context.salt.as_ref(),
+        context.salt,
         &len_as_32le(context.config.secret),
-        context.config.secret.as_ref(),
+        context.config.secret,
         &len_as_32le(context.config.ad),
-        context.config.ad.as_ref(),
+        context.config.ad,
     ];
     let mut out = [0u8; common::PREHASH_SEED_LENGTH];
     blake2b(&mut out[0..common::PREHASH_DIGEST_LENGTH], &input);
@@ -382,34 +375,28 @@ fn index_alpha(context: &Context, position: &Position, pseudo_rand: u32, same_la
         if position.slice == 0 {
             // First slice
             position.index - 1
+        } else if same_lane {
+            // The same lane => add current segment
+            position.slice * context.segment_length + position.index - 1
+        } else if position.index == 0 {
+            position.slice * context.segment_length - 1
         } else {
-            if same_lane {
-                // The same lane => add current segment
-                position.slice * context.segment_length + position.index - 1
-            } else {
-                if position.index == 0 {
-                    position.slice * context.segment_length - 1
-                } else {
-                    position.slice * context.segment_length
-                }
-            }
+            position.slice * context.segment_length
         }
     } else {
         // Second pass
         if same_lane {
             context.lane_length - context.segment_length + position.index - 1
+        } else if position.index == 0 {
+            context.lane_length - context.segment_length - 1
         } else {
-            if position.index == 0 {
-                context.lane_length - context.segment_length - 1
-            } else {
-                context.lane_length - context.segment_length
-            }
+            context.lane_length - context.segment_length
         }
     };
     let reference_area_size = reference_area_size as u64;
     let mut relative_position = pseudo_rand as u64;
-    relative_position = relative_position * relative_position >> 32;
-    relative_position = reference_area_size - 1 - (reference_area_size * relative_position >> 32);
+    relative_position = (relative_position * relative_position) >> 32;
+    relative_position = reference_area_size - 1 - ((reference_area_size * relative_position) >> 32);
 
     // 1.2.5 Computing starting position
     let start_position: u32 = if position.pass != 0 {

--- a/src/decoded.rs
+++ b/src/decoded.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use version::Version;
-use variant::Variant;
+use crate::version::Version;
+use crate::variant::Variant;
 
 /// Structure that contains the decoded data.
 #[derive(Debug, Eq, PartialEq)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -43,13 +43,13 @@ pub fn decode_string(encoded: &str) -> Result<Decoded> {
         let hash = base64::decode(items[5])?;
 
         Ok(Decoded {
-            variant: variant,
-            version: version,
+            variant,
+            version,
             mem_cost: options.mem_cost,
             time_cost: options.time_cost,
             parallelism: options.parallelism,
-            salt: salt,
-            hash: hash,
+            salt,
+            hash,
         })
     } else if items.len() == 5 {
         decode_empty(items[0])?;
@@ -59,18 +59,17 @@ pub fn decode_string(encoded: &str) -> Result<Decoded> {
         let hash = base64::decode(items[4])?;
 
         Ok(Decoded {
-            variant: variant,
+            variant,
             version: Version::Version10,
             mem_cost: options.mem_cost,
             time_cost: options.time_cost,
             parallelism: options.parallelism,
-            salt: salt,
-            hash: hash,
+            salt,
+            hash,
         })
     } else {
-        return Err(Error::DecodingFail);
+        Err(Error::DecodingFail)
     }
-
 }
 
 fn decode_empty(str: &str) -> Result<()> {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -7,12 +7,12 @@
 // except according to those terms.
 
 use base64;
-use super::context::Context;
-use super::decoded::Decoded;
-use super::error::Error;
-use super::result::Result;
-use super::variant::Variant;
-use super::version::Version;
+use crate::context::Context;
+use crate::decoded::Decoded;
+use crate::error::Error;
+use crate::result::Result;
+use crate::variant::Variant;
+use crate::version::Version;
 
 /// Structure containing the options.
 struct Options {
@@ -160,14 +160,14 @@ pub fn num_len(number: u32) -> u32 {
 #[cfg(test)]
 mod tests {
 
-    use config::Config;
-    use context::Context;
-    use decoded::Decoded;
-    use error::Error;
-    use thread_mode::ThreadMode;
-    use variant::Variant;
-    use version::Version;
-    use super::*;
+    use crate::config::Config;
+    use crate::context::Context;
+    use crate::decoded::Decoded;
+    use crate::encoding::{base64_len, decode_string, encode_string, num_len};
+    use crate::error::Error;
+    use crate::thread_mode::ThreadMode;
+    use crate::variant::Variant;
+    use crate::version::Version;
 
     #[test]
     fn base64_len_returns_correct_length() {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -131,7 +131,7 @@ fn decode_version(str: &str) -> Result<Version> {
 }
 
 /// Encodes the hash and context.
-pub fn encode_string(context: &Context, hash: &Vec<u8>) -> String {
+pub fn encode_string(context: &Context, hash: &[u8]) -> String {
     format!(
         "${}$v={}$m={},t={},p={}${}${}",
         context.config.variant,

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use base64;
 use std::{error, fmt};
 
 /// Error type for Argon2 errors.

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,7 +106,7 @@ impl error::Error for Error {
         self.msg()
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,6 @@
 //! This version uses the standard implementation and does not yet implement
 //! optimizations. Therefore, it is not the fastest implementation available.
 
-extern crate base64;
-extern crate blake2b_simd;
-extern crate crossbeam_utils;
-
 mod argon2;
 mod block;
 mod common;
@@ -94,10 +90,10 @@ mod thread_mode;
 mod variant;
 mod version;
 
-pub use argon2::*;
-pub use config::Config;
-pub use error::Error;
-pub use result::Result;
-pub use thread_mode::ThreadMode;
-pub use variant::Variant;
-pub use version::Version;
+pub use crate::argon2::*;
+pub use crate::config::Config;
+pub use crate::error::Error;
+pub use crate::result::Result;
+pub use crate::thread_mode::ThreadMode;
+pub use crate::variant::Variant;
+pub use crate::version::Version;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -31,9 +31,9 @@ impl Memory {
         let total = rows * cols;
         let blocks = vec![Block::zero(); total].into_boxed_slice();
         Memory {
-            rows: rows,
-            cols: cols,
-            blocks: blocks,
+            rows,
+            cols,
+            blocks,
         }
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
-use super::block::Block;
+use crate::block::Block;
 
 /// Structure representing the memory matrix.
 pub struct Memory {
@@ -99,7 +99,7 @@ impl IndexMut<(u32, u32)> for Memory {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    use crate::memory::Memory;
 
     #[test]
     fn new_returns_correct_instance() {

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use std::result;
-use super::error::Error;
+use crate::error::Error;
 
 /// A specialized result type for Argon2 operations.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/thread_mode.rs
+++ b/src/thread_mode.rs
@@ -38,7 +38,7 @@ impl Default for ThreadMode {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+    use crate::thread_mode::ThreadMode;
 
     #[test]
     fn default_returns_correct_thread_mode() {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 use std::fmt;
-use super::error::Error;
-use super::result::Result;
+use crate::error::Error;
+use crate::result::Result;
 
 /// The Argon2 variant.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -95,8 +95,8 @@ impl fmt::Display for Variant {
 #[cfg(test)]
 mod tests {
 
-    use error::Error;
-    use super::*;
+    use crate::error::Error;
+    use crate::variant::Variant;
 
     #[test]
     fn as_lowercase_str_returns_correct_str() {

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 use std::fmt;
-use super::error::Error;
-use super::result::Result;
+use crate::error::Error;
+use crate::result::Result;
 
 /// The Argon2 version.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -61,8 +61,8 @@ impl fmt::Display for Version {
 #[cfg(test)]
 mod tests {
 
-    use error::Error;
-    use super::*;
+    use crate::error::Error;
+    use crate::version::Version;
 
     #[test]
     fn as_u32_returns_correct_u32() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,9 +8,6 @@
 
 // These tests are based on Argon's test.c test suite.
 
-extern crate argon2;
-extern crate hex;
-
 use argon2::{Error, Config, ThreadMode, Variant, Version};
 use hex::ToHex;
 


### PR DESCRIPTION
* Use 2018 edition
* Use &dyn error::Error instead of &error::Error
* Fix clippy lints
* Allow callers of encode_string to pass any &[u8]