### PR TITLE
Make parallellism optional via feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ keywords = ["argon2", "argon2d", "argon2i", "hash", "password"]
 [lib]
 name = "argon2"
 
+[features]
+default = ["crossbeam-utils"]
+
 [dependencies]
 base64 = "0.11"
 blake2b_simd = "0.5"
 constant_time_eq = "0.1.4"
-crossbeam-utils = "0.7"
+crossbeam-utils = { version = "0.7", optional = true }
 
 [dev-dependencies]
 hex = "0.3"

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -83,8 +83,10 @@ pub fn encoded_len(
 /// let salt = b"somesalt";
 /// let mut config = Config::default();
 /// config.variant = Variant::Argon2d;
-/// config.lanes = 4;
-/// config.thread_mode = ThreadMode::Parallel;
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.lanes = 4;")]
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.thread_mode = ThreadMode::Parallel;")]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.lanes = 1;")]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.thread_mode = ThreadMode::Sequential;")]
 /// let encoded = argon2::hash_encoded(pwd, salt, &config).unwrap();
 /// ```
 pub fn hash_encoded(pwd: &[u8], salt: &[u8], config: &Config) -> Result<String> {
@@ -293,8 +295,10 @@ pub fn hash_encoded_std(
 /// let salt = b"somesalt";
 /// let mut config = Config::default();
 /// config.variant = Variant::Argon2d;
-/// config.lanes = 4;
-/// config.thread_mode = ThreadMode::Parallel;
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.lanes = 4;")]
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.thread_mode = ThreadMode::Parallel;")]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.lanes = 1;")]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.thread_mode = ThreadMode::Sequential;")]
 /// let vec = argon2::hash_raw(pwd, salt, &config).unwrap();
 /// ```
 pub fn hash_raw(pwd: &[u8], salt: &[u8], config: &Config) -> Result<Vec<u8>> {

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,6 +13,7 @@ use crate::memory::Memory;
 use crate::variant::Variant;
 use crate::version::Version;
 use blake2b_simd::Params;
+#[cfg(feature = "crossbeam-utils")]
 use crossbeam_utils::thread::scope;
 use std::mem;
 
@@ -183,6 +184,7 @@ fn fill_first_blocks(context: &Context, memory: &mut Memory, h0: &mut [u8]) {
     }
 }
 
+#[cfg(feature = "crossbeam-utils")]
 fn fill_memory_blocks_mt(context: &Context, memory: &mut Memory) {
     for p in 0..context.config.time_cost {
         for s in 0..common::SYNC_POINTS {
@@ -201,6 +203,11 @@ fn fill_memory_blocks_mt(context: &Context, memory: &mut Memory) {
             });
         }
     }
+}
+
+#[cfg(not(feature = "crossbeam-utils"))]
+fn fill_memory_blocks_mt(_: &Context, _: &mut Memory) {
+    unimplemented!()
 }
 
 fn fill_memory_blocks_st(context: &Context, memory: &mut Memory) {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -159,11 +159,16 @@ pub fn num_len(number: u32) -> u32 {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(feature = "crossbeam-utils")]
     use crate::config::Config;
+    #[cfg(feature = "crossbeam-utils")]
     use crate::context::Context;
     use crate::decoded::Decoded;
-    use crate::encoding::{base64_len, decode_string, encode_string, num_len};
+    use crate::encoding::{base64_len, decode_string, num_len};
+    #[cfg(feature = "crossbeam-utils")]
+    use crate::encoding::encode_string;
     use crate::error::Error;
+    #[cfg(feature = "crossbeam-utils")]
     use crate::thread_mode::ThreadMode;
     use crate::variant::Variant;
     use crate::version::Version;
@@ -359,6 +364,7 @@ mod tests {
         assert_eq!(result, Err(Error::DecodingFail));
     }
 
+    #[cfg(feature = "crossbeam-utils")]
     #[test]
     fn encode_string_returns_correct_string() {
         let hash = b"12345678901234567890123456789012".to_vec();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,10 @@
 //!     version: Version::Version13,
 //!     mem_cost: 65536,
 //!     time_cost: 10,
-//!     lanes: 4,
-//!     thread_mode: ThreadMode::Parallel,
+#![cfg_attr(feature = "crossbeam-utils", doc = "    lanes: 4,")]
+#![cfg_attr(feature = "crossbeam-utils", doc = "    thread_mode: ThreadMode::Parallel,")]
+#![cfg_attr(not(feature = "crossbeam-utils"), doc = "    lanes: 1,")]
+#![cfg_attr(not(feature = "crossbeam-utils"), doc = "    thread_mode: ThreadMode::Sequential,")]
 //!     secret: &[],
 //!     ad: &[],
 //!     hash_length: 32

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -37,6 +37,7 @@ impl Memory {
         }
     }
 
+    #[cfg(feature = "crossbeam-utils")]
     /// Gets the mutable lanes representation of the memory matrix.
     pub fn as_lanes_mut(&mut self) -> Vec<&mut Memory> {
         let ptr: *mut Memory = self;
@@ -111,6 +112,7 @@ mod tests {
         assert_eq!(memory.blocks.len(), 512);
     }
 
+    #[cfg(feature = "crossbeam-utils")]
     #[test]
     fn as_lanes_mut_returns_correct_vec() {
         let mut memory = Memory::new(4, 128);

--- a/src/thread_mode.rs
+++ b/src/thread_mode.rs
@@ -13,11 +13,13 @@ pub enum ThreadMode {
     /// Run in one thread.
     Sequential,
 
+    #[cfg(feature = "crossbeam-utils")]
     /// Run in the same number of threads as the number of lanes.
     Parallel,
 }
 
 impl ThreadMode {
+    #[cfg(feature = "crossbeam-utils")]
     /// Create a thread mode from the threads count.
     pub fn from_threads(threads: u32) -> ThreadMode {
         if threads > 1 {
@@ -25,6 +27,12 @@ impl ThreadMode {
         } else {
             ThreadMode::Sequential
         }
+    }
+
+    #[cfg(not(feature = "crossbeam-utils"))]
+    pub fn from_threads(threads: u32) -> ThreadMode {
+        assert_eq!(threads, 1);
+        Self::default()
     }
 }
 
@@ -45,6 +53,7 @@ mod tests {
         assert_eq!(ThreadMode::default(), ThreadMode::Sequential);
     }
 
+    #[cfg(feature = "crossbeam-utils")]
     #[test]
     fn from_threads_returns_correct_thread_mode() {
         assert_eq!(ThreadMode::from_threads(0), ThreadMode::Sequential);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -78,6 +78,7 @@ fn test_argon2d_version10_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2d_version10_5() {
     hash_test(
@@ -229,6 +230,7 @@ fn test_argon2d_version13_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2d_version13_5() {
     hash_test(
@@ -380,6 +382,7 @@ fn test_argon2i_version10_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2i_version10_5() {
     hash_test(
@@ -531,6 +534,7 @@ fn test_argon2i_version13_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2i_version13_5() {
     hash_test(
@@ -682,6 +686,7 @@ fn test_argon2id_version10_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2id_version10_5() {
     hash_test(
@@ -833,6 +838,7 @@ fn test_argon2id_version13_4() {
     );
 }
 
+#[cfg(feature = "crossbeam-utils")]
 #[test]
 fn test_argon2id_version13_5() {
     hash_test(


### PR DESCRIPTION
Since `ThreadMode::Parallel` isn't used by default, it might make sense to make the dependency optional.