### PR TITLE
Bump constant_time_eq to 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["crossbeam-utils"]
 [dependencies]
 base64 = "0.13"
 blake2b_simd = "1.0"
-constant_time_eq = "0.1.5"
+constant_time_eq = "0.2.6"
 crossbeam-utils = { version = "0.8", optional = true }
 serde = { version = "1.0.133", optional = true, features=["derive"] }
 


### PR DESCRIPTION
blake2b_simd depends on that version thus causing duplicate versions of that crate.