### PR TITLE
Bring back parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ keywords = ["argon2", "argon2d", "argon2i", "hash", "password"]
 [lib]
 name = "argon2"
 
+[features]
+default = ["crossbeam-utils"]
+
 [dependencies]
 base64 = "0.21"
 blake2b_simd = "1.0"
 constant_time_eq = "0.3.0"
+crossbeam-utils = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true, features=["derive"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ assert!(matches);
 Create a password hash with custom settings and verify it:
 
 ```rust
-use argon2::{self, Config, Variant, Version};
+use argon2::{self, Config, ThreadMode, Variant, Version};
 
 let password = b"password";
 let salt = b"othersalt";
@@ -49,6 +49,7 @@ let config = Config {
     mem_cost: 65536,
     time_cost: 10,
     lanes: 4,
+    thread_mode: ThreadMode::Parallel,
     secret: &[],
     ad: &[],
     hash_length: 32

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -213,6 +213,12 @@ mod tests {
 
     #[test]
     fn single_thread_verification_multi_lane_hash() {
+        /*
+        let hash = hash_encoded(b"foo", b"abcdefghijklmnopqrstuvwxyz", &Config {
+            lanes: 4, thread_mode: ThreadMode::Parallel,
+            ..Config::default()
+        });
+        */
         let hash = "$argon2i$v=19$m=4096,t=3,p=4$YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo$BvBk2OaSofBHfbrUW61nHrWB/43xgfs/QJJ5DkMAd8I";
         verify_encoded(hash, b"foo").unwrap();
     }

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -228,7 +228,8 @@ pub fn verify_raw(pwd: &[u8], salt: &[u8], hash: &[u8], config: &Config) -> Resu
 fn run(context: &Context) -> Vec<u8> {
     let mut memory = Memory::new(context.config.lanes, context.lane_length);
     core::initialize(context, &mut memory);
-    core::fill_memory_blocks(context, &mut memory);
+    // SAFETY: `memory` is consistent with `context` by construction.
+    unsafe { core::fill_memory_blocks(context, &mut memory) };
     core::finalize(context, &memory)
 }
 

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -12,6 +12,7 @@ use crate::core;
 use crate::encoding;
 use crate::memory::Memory;
 use crate::result::Result;
+use crate::thread_mode::ThreadMode;
 use crate::variant::Variant;
 use crate::version::Version;
 
@@ -73,16 +74,25 @@ pub fn encoded_len(
 /// ```
 ///
 ///
-/// Create an Argon2d encoded hash with 4 lanes:
+/// Create an Argon2d encoded hash with 4 lanes and parallel execution:
 ///
 /// ```
-/// use argon2::{self, Config, Variant};
+/// use argon2::{self, Config, ThreadMode, Variant};
 ///
 /// let pwd = b"password";
 /// let salt = b"somesalt";
 /// let mut config = Config::default();
 /// config.variant = Variant::Argon2d;
-/// config.lanes = 4;
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.lanes = 4;")]
+#[cfg_attr(
+    feature = "crossbeam-utils",
+    doc = "config.thread_mode = ThreadMode::Parallel;"
+)]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.lanes = 1;")]
+#[cfg_attr(
+    not(feature = "crossbeam-utils"),
+    doc = "config.thread_mode = ThreadMode::Sequential;"
+)]
 /// let encoded = argon2::hash_encoded(pwd, salt, &config).unwrap();
 /// ```
 pub fn hash_encoded(pwd: &[u8], salt: &[u8], config: &Config) -> Result<String> {
@@ -108,16 +118,25 @@ pub fn hash_encoded(pwd: &[u8], salt: &[u8], config: &Config) -> Result<String> 
 /// ```
 ///
 ///
-/// Create an Argon2d hash with 4 lanes:
+/// Create an Argon2d hash with 4 lanes and parallel execution:
 ///
 /// ```
-/// use argon2::{self, Config, Variant};
+/// use argon2::{self, Config, ThreadMode, Variant};
 ///
 /// let pwd = b"password";
 /// let salt = b"somesalt";
 /// let mut config = Config::default();
 /// config.variant = Variant::Argon2d;
-/// config.lanes = 4;
+#[cfg_attr(feature = "crossbeam-utils", doc = "config.lanes = 4;")]
+#[cfg_attr(
+    feature = "crossbeam-utils",
+    doc = "config.thread_mode = ThreadMode::Parallel;"
+)]
+#[cfg_attr(not(feature = "crossbeam-utils"), doc = "config.lanes = 1;")]
+#[cfg_attr(
+    not(feature = "crossbeam-utils"),
+    doc = "config.thread_mode = ThreadMode::Sequential;"
+)]
 /// let vec = argon2::hash_raw(pwd, salt, &config).unwrap();
 /// ```
 pub fn hash_raw(pwd: &[u8], salt: &[u8], config: &Config) -> Result<Vec<u8>> {
@@ -160,12 +179,18 @@ pub fn verify_encoded(encoded: &str, pwd: &[u8]) -> Result<bool> {
 /// ```
 pub fn verify_encoded_ext(encoded: &str, pwd: &[u8], secret: &[u8], ad: &[u8]) -> Result<bool> {
     let decoded = encoding::decode_string(encoded)?;
+    let threads = if cfg!(feature = "crossbeam-utils") {
+        decoded.parallelism
+    } else {
+        1
+    };
     let config = Config {
         variant: decoded.variant,
         version: decoded.version,
         mem_cost: decoded.mem_cost,
         time_cost: decoded.time_cost,
         lanes: decoded.parallelism,
+        thread_mode: ThreadMode::from_threads(threads),
         secret,
         ad,
         hash_length: decoded.hash.len() as u32,

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -202,7 +202,6 @@ pub fn verify_encoded_ext(encoded: &str, pwd: &[u8], secret: &[u8], ad: &[u8]) -
 ///
 /// # Examples
 ///
-///
 /// ```
 /// use argon2::{self, Config};
 ///
@@ -228,7 +227,7 @@ pub fn verify_raw(pwd: &[u8], salt: &[u8], hash: &[u8], config: &Config) -> Resu
 fn run(context: &Context) -> Vec<u8> {
     let mut memory = Memory::new(context.config.lanes, context.lane_length);
     core::initialize(context, &mut memory);
-    // SAFETY: `memory` is consistent with `context` by construction.
+    // SAFETY: `memory` is constructed from `context`.
     unsafe { core::fill_memory_blocks(context, &mut memory) };
     core::finalize(context, &memory)
 }

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -238,13 +238,41 @@ mod tests {
 
     #[test]
     fn single_thread_verification_multi_lane_hash() {
-        /*
-        let hash = hash_encoded(b"foo", b"abcdefghijklmnopqrstuvwxyz", &Config {
-            lanes: 4, thread_mode: ThreadMode::Parallel,
-            ..Config::default()
-        });
-        */
-        let hash = "$argon2i$v=19$m=4096,t=3,p=4$YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo$BvBk2OaSofBHfbrUW61nHrWB/43xgfs/QJJ5DkMAd8I";
-        verify_encoded(hash, b"foo").unwrap();
+        let hash = "$argon2i$v=19$m=4096,t=3,p=4$YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo$\
+                    BvBk2OaSofBHfbrUW61nHrWB/43xgfs/QJJ5DkMAd8I";
+        let res = verify_encoded(hash, b"foo").unwrap();
+        assert!(res);
+    }
+
+    #[test]
+    fn test_argon2id_for_miri() {
+        let hash = "$argon2id$v=19$m=256,t=2,p=16$c29tZXNhbHQ$\
+                    0gasyPnKXiBHQ5bft/bd4jrmy2DdtrLTX3JR9co7fRY";
+        let res = verify_encoded(hash, b"password").unwrap();
+        assert!(res);
+    }
+
+    #[test]
+    fn test_argon2id_for_miri_2() {
+        let hash = "$argon2id$v=19$m=512,t=2,p=8$c29tZXNhbHQ$\
+                    qgW4yz2jO7oklapDpVwzUYgfDLzfwkppGTvhRDDBjkY";
+        let res = verify_encoded(hash, b"password").unwrap();
+        assert!(res);
+    }
+
+    #[test]
+    fn test_argon2d_for_miri() {
+        let hash = "$argon2d$v=19$m=256,t=2,p=16$c29tZXNhbHQ$\
+                    doW5kZ/0cTwqwbYTwr9JD0wNwy3tMyJMMk9ojGsC8bk";
+        let res = verify_encoded(hash, b"password").unwrap();
+        assert!(res);
+    }
+
+    #[test]
+    fn test_argon2i_for_miri() {
+        let hash = "$argon2i$v=19$m=256,t=2,p=16$c29tZXNhbHQ$\
+                    c1suSp12ZBNLSuyhD8pJriM2r5jP2kgZ5QdDAk3+HaY";
+        let res = verify_encoded(hash, b"password").unwrap();
+        assert!(res);
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -11,7 +11,13 @@ use std::fmt;
 use std::fmt::Debug;
 use std::ops::{BitXorAssign, Index, IndexMut};
 
-/// Structure for the (1KB) memory block implemented as 128 64-bit words.
+/// Structure for the (1 KiB) memory block implemented as 128 64-bit words.
+// Blocks are 128-byte aligned to prevent false sharing. This specific alignment value replicates
+// what `crossbeam-utils::CachePadded` does on modern architectures, which either use 128-byte
+// cache lines (aarch64) or pull 64-byte cache lines in pairs (x86-64), without the need for
+// stubbing that type in when  `crossbeam-utils` isn't available. As blocks are fairly large (1
+// KiB), this simplification shouldn't severy affect the (rarer) targets with smaller cache lines.
+#[repr(align(128))]
 pub struct Block([u64; common::QWORDS_IN_BLOCK]);
 
 impl Block {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::thread_mode::ThreadMode;
 use crate::variant::Variant;
 use crate::version::Version;
 
@@ -14,7 +15,7 @@ use crate::version::Version;
 /// # Examples
 ///
 /// ```
-/// use argon2::{Config, Variant, Version};
+/// use argon2::{Config, ThreadMode, Variant, Version};
 ///
 /// let config = Config::default();
 /// assert_eq!(config.ad, &[]);
@@ -24,6 +25,7 @@ use crate::version::Version;
 /// assert_eq!(config.secret, &[]);
 /// assert_eq!(config.time_cost, 2);
 /// assert_eq!(config.variant, Variant::Argon2id);
+/// assert_eq!(config.thread_mode, ThreadMode::Sequential);
 /// assert_eq!(config.version, Version::Version13);
 /// ```
 #[derive(Clone, Debug, PartialEq)]
@@ -42,6 +44,9 @@ pub struct Config<'a> {
 
     /// The key.
     pub secret: &'a [u8],
+
+    /// The thread mode.
+    pub thread_mode: ThreadMode,
 
     /// The number of passes.
     pub time_cost: u32,
@@ -62,6 +67,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 4096,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 3,
             variant: Variant::Argon2i,
             version: Version::Version13,
@@ -76,6 +82,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 47104,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 1,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -90,6 +97,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 19456,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 2,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -104,6 +112,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 12288,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 3,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -118,6 +127,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 9216,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 4,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -132,6 +142,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 7168,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 5,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -146,6 +157,7 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 2097152,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 1,
             variant: Variant::Argon2id,
             version: Version::Version13,
@@ -160,10 +172,15 @@ impl<'a> Config<'a> {
             lanes: 1,
             mem_cost: 65536,
             secret: &[],
+            thread_mode: ThreadMode::default(),
             time_cost: 3,
             variant: Variant::Argon2id,
             version: Version::Version13,
         }
+    }
+
+    pub fn uses_sequential(&self) -> bool {
+        self.thread_mode == ThreadMode::Sequential || self.lanes == 1
     }
 }
 
@@ -178,6 +195,7 @@ impl<'a> Default for Config<'a> {
 mod tests {
 
     use crate::config::Config;
+    use crate::thread_mode::ThreadMode;
     use crate::variant::Variant;
     use crate::version::Version;
 
@@ -189,6 +207,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 19 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 2);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -202,6 +221,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 4096);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 3);
         assert_eq!(config.variant, Variant::Argon2i);
         assert_eq!(config.version, Version::Version13);
@@ -215,6 +235,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 46 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 1);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -228,6 +249,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 19 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 2);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -241,6 +263,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 12 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 3);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -254,6 +277,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 9 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 4);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -267,6 +291,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 7 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 5);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -280,6 +305,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 2 * 1024 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 1);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);
@@ -293,6 +319,7 @@ mod tests {
         assert_eq!(config.lanes, 1);
         assert_eq!(config.mem_cost, 64 * 1024);
         assert_eq!(config.secret, &[]);
+        assert_eq!(config.thread_mode, ThreadMode::Sequential);
         assert_eq!(config.time_cost, 3);
         assert_eq!(config.variant, Variant::Argon2id);
         assert_eq!(config.version, Version::Version13);

--- a/src/context.rs
+++ b/src/context.rs
@@ -118,6 +118,7 @@ mod tests {
     use crate::config::Config;
     use crate::context::Context;
     use crate::error::Error;
+    use crate::thread_mode::ThreadMode;
     use crate::variant::Variant;
     use crate::version::Version;
 
@@ -129,6 +130,7 @@ mod tests {
             lanes: 4,
             mem_cost: 4096,
             secret: b"secret",
+            thread_mode: ThreadMode::Sequential,
             time_cost: 3,
             variant: Variant::Argon2i,
             version: Version::Version13,

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,6 +13,8 @@ use crate::memory::Memory;
 use crate::variant::Variant;
 use crate::version::Version;
 use blake2b_simd::Params;
+#[cfg(feature = "crossbeam-utils")]
+use crossbeam_utils::thread::scope;
 
 /// Position of the block currently being operated on.
 #[derive(Clone, Debug)]
@@ -30,7 +32,11 @@ pub fn initialize(context: &Context, memory: &mut Memory) {
 
 /// Fills all the memory blocks.
 pub fn fill_memory_blocks(context: &Context, memory: &mut Memory) {
-    fill_memory_blocks_st(context, memory);
+    if context.config.uses_sequential() {
+        fill_memory_blocks_st(context, memory);
+    } else {
+        fill_memory_blocks_mt(context, memory);
+    }
 }
 
 /// Calculates the final hash and returns it.
@@ -175,6 +181,32 @@ fn fill_first_blocks(context: &Context, memory: &mut Memory, h0: &mut [u8]) {
         h0[start..(start + 4)].clone_from_slice(&u32::to_le_bytes(1));
         hprime(memory[(lane, 1)].as_u8_mut(), &h0);
     }
+}
+
+#[cfg(feature = "crossbeam-utils")]
+fn fill_memory_blocks_mt(context: &Context, memory: &mut Memory) {
+    for p in 0..context.config.time_cost {
+        for s in 0..common::SYNC_POINTS {
+            let _ = scope(|scoped| {
+                for (l, mem) in (0..context.config.lanes).zip(memory.as_lanes_mut()) {
+                    let position = Position {
+                        pass: p,
+                        lane: l,
+                        slice: s,
+                        index: 0,
+                    };
+                    scoped.spawn(move |_| {
+                        fill_segment(context, &position, mem);
+                    });
+                }
+            });
+        }
+    }
+}
+
+#[cfg(not(feature = "crossbeam-utils"))]
+fn fill_memory_blocks_mt(_: &Context, _: &mut Memory) {
+    unimplemented!()
 }
 
 fn fill_memory_blocks_st(context: &Context, memory: &mut Memory) {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -158,10 +158,8 @@ pub fn num_len(number: u32) -> u32 {
 #[cfg(test)]
 mod tests {
 
-    use crate::config::Config;
-    use crate::context::Context;
     use crate::decoded::Decoded;
-    use crate::encoding::{base64_len, decode_string, encode_string, num_len};
+    use crate::encoding::{base64_len, decode_string, num_len};
     use crate::error::Error;
     use crate::variant::Variant;
     use crate::version::Version;
@@ -357,6 +355,7 @@ mod tests {
         assert_eq!(result, Err(Error::DecodingFail));
     }
 
+    #[cfg(feature = "crossbeam-utils")]
     #[test]
     fn encode_string_returns_correct_string() {
         let hash = b"12345678901234567890123456789012".to_vec();

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -158,9 +158,17 @@ pub fn num_len(number: u32) -> u32 {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(feature = "crossbeam-utils")]
+    use crate::config::Config;
+    #[cfg(feature = "crossbeam-utils")]
+    use crate::context::Context;
     use crate::decoded::Decoded;
+    #[cfg(feature = "crossbeam-utils")]
+    use crate::encoding::encode_string;
     use crate::encoding::{base64_len, decode_string, num_len};
     use crate::error::Error;
+    #[cfg(feature = "crossbeam-utils")]
+    use crate::thread_mode::ThreadMode;
     use crate::variant::Variant;
     use crate::version::Version;
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -365,6 +365,7 @@ mod tests {
             lanes: 1,
             mem_cost: 4096,
             secret: &[],
+            thread_mode: ThreadMode::Parallel,
             time_cost: 3,
             variant: Variant::Argon2i,
             version: Version::Version13,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! Create a password hash with custom settings and verify it:
 //!
 //! ```rust
-//! use argon2::{self, Config, Variant, Version};
+//! use argon2::{self, Config, ThreadMode, Variant, Version};
 //!
 //! let password = b"password";
 //! let salt = b"othersalt";
@@ -53,7 +53,16 @@
 //!     version: Version::Version13,
 //!     mem_cost: 65536,
 //!     time_cost: 10,
-//!     lanes: 4,
+#![cfg_attr(feature = "crossbeam-utils", doc = "    lanes: 4,")]
+#![cfg_attr(
+    feature = "crossbeam-utils",
+    doc = "    thread_mode: ThreadMode::Parallel,"
+)]
+#![cfg_attr(not(feature = "crossbeam-utils"), doc = "    lanes: 1,")]
+#![cfg_attr(
+    not(feature = "crossbeam-utils"),
+    doc = "    thread_mode: ThreadMode::Sequential,"
+)]
 //!     secret: &[],
 //!     ad: &[],
 //!     hash_length: 32
@@ -85,6 +94,7 @@ mod encoding;
 mod error;
 mod memory;
 mod result;
+mod thread_mode;
 mod variant;
 mod version;
 
@@ -92,5 +102,6 @@ pub use crate::argon2::*;
 pub use crate::config::Config;
 pub use crate::error::Error;
 pub use crate::result::Result;
+pub use crate::thread_mode::ThreadMode;
 pub use crate::variant::Variant;
 pub use crate::version::Version;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -38,7 +38,6 @@ impl Memory {
     }
 
     /// Returns a pointer to the flat array of blocks useful for parallel disjoint access.
-    #[cfg(feature = "crossbeam-utils")]
     pub fn as_unsafe_blocks(&mut self) -> UnsafeBlocks<'_> {
         UnsafeBlocks {
             blocks: NonNull::new(self.blocks.as_mut_ptr()).unwrap(),
@@ -64,7 +63,6 @@ impl UnsafeBlocks<'_> {
     /// The caller must ensure that `index` is in bounds, no mutable references exist or are
     /// created to the corresponding block, and no data races happen while the returned reference
     /// lives.
-    #[cfg(feature = "crossbeam-utils")]
     pub unsafe fn get_unchecked(&self, index: usize) -> &Block {
         // SAFETY: the caller promises that the `index` is in bounds; therefore, we're within the
         // bounds of the allocated object, and the offset in bytes fits in an `isize`.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -32,6 +32,17 @@ impl Memory {
         let blocks = vec![Block::zero(); total].into_boxed_slice();
         Memory { rows, cols, blocks }
     }
+
+    #[cfg(feature = "crossbeam-utils")]
+    /// Gets the mutable lanes representation of the memory matrix.
+    pub fn as_lanes_mut(&mut self) -> Vec<&mut Memory> {
+        let ptr: *mut Memory = self;
+        let mut vec = Vec::with_capacity(self.rows);
+        for _ in 0..self.rows {
+            vec.push(unsafe { &mut (*ptr) });
+        }
+        vec
+    }
 }
 
 impl Debug for Memory {
@@ -94,5 +105,13 @@ mod tests {
         assert_eq!(memory.rows, lanes as usize);
         assert_eq!(memory.cols, lane_length as usize);
         assert_eq!(memory.blocks.len(), 512);
+    }
+
+    #[cfg(feature = "crossbeam-utils")]
+    #[test]
+    fn as_lanes_mut_returns_correct_vec() {
+        let mut memory = Memory::new(4, 128);
+        let lanes = memory.as_lanes_mut();
+        assert_eq!(lanes.len(), 4);
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -36,7 +36,7 @@ impl Memory {
         Memory { rows, cols, blocks }
     }
 
-    /// Return a wrapped pointer to the flat array of blocks for parallel disjoint access.
+    /// Returns a pointer to the flat array of blocks useful for parallel disjoint access.
     #[cfg(feature = "crossbeam-utils")]
     pub fn as_unsafe_blocks(&mut self) -> UnsafeBlocks<'_> {
         UnsafeBlocks {
@@ -46,9 +46,11 @@ impl Memory {
     }
 }
 
-/// Wrapped pointer to the flat array of blocks for parallel disjoint access.
+/// A wrapped raw pointer to the flat array of blocks, useful for parallel disjoint access.
 ///
-/// All operations are unchecked and require `unsafe`.
+/// All operations on this type are unchecked and require `unsafe`. The caller is responsible for
+/// accessing the blocks in a manner that follows the aliasing rules and that doesn't result in
+/// data races.
 pub struct UnsafeBlocks<'a> {
     ptr: *mut [Block],
     phantom: PhantomData<&'a [Block]>,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -85,6 +85,14 @@ impl UnsafeBlocks<'_> {
         let mut ptr = unsafe { self.blocks.add(index) };
         // SAFETY: the caller promises that there are no other references, accesses, or data races
         // affecting the target `Block`; and `ptr` points to a valid and aligned `Block`.
+        //
+        // Also note that this isn't interior mutability, as we're going through a `NonNull`
+        // pointer derived from a mutable reference (and interior mutability is not transitive
+        // through raw pointers[1][2][3]).
+        //
+        // [1]: https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#interior-mutability
+        // [2]: https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html?highlight=undefin#r-undefined.immutable
+        // [3]: https://github.com/rust-lang/reference/issues/1227
         unsafe { ptr.as_mut() }
     }
 }

--- a/src/thread_mode.rs
+++ b/src/thread_mode.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 Xidorn Quan <me@upsuper.org>
+// Copyright (c) 2017 Martijn Rijkeboer <mrr@sru-systems.com>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// The thread mode used to perform the hashing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThreadMode {
+    /// Run in one thread.
+    Sequential,
+
+    #[cfg(feature = "crossbeam-utils")]
+    /// Run in the same number of threads as the number of lanes.
+    Parallel,
+}
+
+impl ThreadMode {
+    #[cfg(feature = "crossbeam-utils")]
+    /// Create a thread mode from the threads count.
+    pub fn from_threads(threads: u32) -> ThreadMode {
+        if threads > 1 {
+            ThreadMode::Parallel
+        } else {
+            ThreadMode::Sequential
+        }
+    }
+
+    #[cfg(not(feature = "crossbeam-utils"))]
+    pub fn from_threads(threads: u32) -> ThreadMode {
+        assert_eq!(threads, 1);
+        Self::default()
+    }
+}
+
+impl Default for ThreadMode {
+    fn default() -> ThreadMode {
+        ThreadMode::Sequential
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::thread_mode::ThreadMode;
+
+    #[test]
+    fn default_returns_correct_thread_mode() {
+        assert_eq!(ThreadMode::default(), ThreadMode::Sequential);
+    }
+
+    #[cfg(feature = "crossbeam-utils")]
+    #[test]
+    fn from_threads_returns_correct_thread_mode() {
+        assert_eq!(ThreadMode::from_threads(0), ThreadMode::Sequential);
+        assert_eq!(ThreadMode::from_threads(1), ThreadMode::Sequential);
+        assert_eq!(ThreadMode::from_threads(2), ThreadMode::Parallel);
+        assert_eq!(ThreadMode::from_threads(10), ThreadMode::Parallel);
+        assert_eq!(ThreadMode::from_threads(100), ThreadMode::Parallel);
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,7 +8,7 @@
 
 // These tests are based on Argon's test.c test suite.
 
-use argon2::{Config, Error, Variant, Version};
+use argon2::{Config, Error, ThreadMode, Variant, Version};
 use hex::ToHex;
 
 #[cfg(not(debug_assertions))]
@@ -1014,6 +1014,7 @@ fn test_hash_raw_with_not_enough_memory() {
         mem_cost: 2,
         time_cost: 2,
         lanes: 1,
+        thread_mode: ThreadMode::Sequential,
         secret: &[],
         ad: &[],
         hash_length: 32,
@@ -1032,6 +1033,7 @@ fn test_hash_raw_with_too_short_salt() {
         mem_cost: 2048,
         time_cost: 2,
         lanes: 1,
+        thread_mode: ThreadMode::Sequential,
         secret: &[],
         ad: &[],
         hash_length: 32,
@@ -1051,12 +1053,14 @@ fn hash_test(
     hex: &str,
     enc: &str,
 ) {
+    let threads = if cfg!(feature = "crossbeam-utils") { p } else { 1 };
     let config = Config {
         variant: var,
         version: ver,
         mem_cost: m,
         time_cost: t,
         lanes: p,
+        thread_mode: ThreadMode::from_threads(threads),
         secret: &[],
         ad: &[],
         hash_length: 32,


### PR DESCRIPTION
This is an attempt to bring back parallelism (which was removed in 3b6dcc197ebb due to #41).

I've started by reverting the three commits related to the removal of parallelism, then replaced `Memory::as_lanes_mut` with a (wrapped) raw pointer (type) and changed `fill_segment` to directly obtain disjoint shared or mutable block references as needed.

Essentially, this relies on the fact that Argon2 does its passes over memory in slices, and the algorithm is specifically designed so that all segments of a slice can be computed in parallel (without data races or atomics). Additionally, synchronization between threads (in the memory ordering sense) is performed after each slice is processed, when the thread `scope` drops.

As pointed out in #41, it was also necessary to move the `unsafe` boundary up, since the soundness of these operations depends on `fill_segment` and its ancestors having received correct arguments. I've also added the corresponding safety docs and comments.

Finally, I've added a few more tests, which successfully run in Miri. The new tests use little memory, but more lanes, and take a few minutes (each) to run in Miri. I also ran an existing 4 MiB test, which took 20 or so minutes.

---

P.S. Feel free to squash the individual commits when/if the time comes to merge this PR. I've intentionally left the intermediate steps I took in case the review sparks discussions on some of the choices I made.